### PR TITLE
Readme updates

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -918,7 +918,7 @@ Create a Textpattern form called "my_com_connect_to_form", containing:
 
 bc(language-markup). <txp:php>
     global $com_connect_form;
-    switch($com_connect_form['Department'])
+    switch($com_connect_form['Department'][0])
     {
         case 'Support':
             echo 'crew@example.com';
@@ -931,7 +931,7 @@ bc(language-markup). <txp:php>
     }
 </txp:php>
 
-The @label@ used in the @com_connect_select@ tag must be identical to the corresponsing variable in the @to_form@. Here we used @Department@.
+The @label@ used in the @com_connect_select@ tag must be identical to the corresponding variable in the @to_form@. Here we used @Department@.
 
 A 'default' email address in the @to_form@ is specified to ensure that a valid email address is used in cases where you add or change a select/radio option and forget to update the @to_form@.
 


### PR DESCRIPTION
- Addition of [0] to the `to_form` instructions
- Typo